### PR TITLE
Give full path for where to clone jblas.

### DIFF
--- a/build-jblas-ec2.sh
+++ b/build-jblas-ec2.sh
@@ -4,7 +4,7 @@ set -e
 
 # Build JBLAS for this machine
 rm -rf /root/jblas
-git clone https://github.com/mikiobraun/jblas.git
+git clone https://github.com/mikiobraun/jblas.git /root/jblas
 pushd /root/jblas
 
   git checkout jblas-1.2.3


### PR DESCRIPTION
Without this commit, this build-jblas-ec2.sh script fails when it's
not called from the root directory.
